### PR TITLE
Allow for PaddleOCR versions greater than 2.7.0.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     install_requires=[
         'thefuzz>=0.19',
         'python-Levenshtein>=0.12',
-        'paddleocr==2.7.0.2',
+        'paddleocr>=2.6',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/videocr/models.py
+++ b/videocr/models.py
@@ -19,6 +19,10 @@ class PredictedFrames:
     text: str
 
     def __init__(self, index: int, pred_data: list[list], conf_threshold: float):
+        # Fix for PaddleOCR versions greater than 2.7.0.2
+        if not pred_data or pred_data[0] is None:
+            pred_data = [[]]
+
         self.start_index = index
         self.end_index = index
         self.lines = []


### PR DESCRIPTION
As mentioned in Issue #16 there was a breaking change for PaddleOCR versions greater than 2.7.0.2 for this repo. The problem is that in newer versions PaddleOCR returns a list containing none ([None]) whereas before it returned [[]] when there is no detected text in the image.

There are certainly several ways to fix this issue, but I just added a short if statement to detect this. Now it also works with versions greater than 2.7.0.2. I tested all version up to the latest one 2.10.0.