### PR TITLE
Update Python compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ example.srt:
 ```
 
 ## Install prerequisites
-Python 3.7 - 3.10
+Python 3.7 - 3.12
 
 paddlepaddle or paddlepaddle-gpu See https://www.paddlepaddle.org.cn/install/quick?docurl=/documentation/docs/en/install/pip/linux-pip_en.html
 


### PR DESCRIPTION
My last commit where I allowed for newer PaddleOCR versions than 2.7.02. also allowed for newer python versions indirectly.
We were limited to Python 3.10 due to PyMuPDF. PaddleOCR 2.7.0.2 required a PyMuPDF version < 1.21.0 and 1.21.0 is actually the first version that supports Python 3.11 for example. By removing the limitation of the PaddleOCR version this limit was also removed.
Now this project works perfectly fine with Python 3.12. The repo can be downloaded in its current form on such version and it will work right away out of the box. Tested using Python 3.12.6.

Edit: I also worked on your TODO list. :-) Today I uploaded a release with a GUI version that lets the user control everything via a few clicks.
I am aware of video-subtitle-extractor but I really like this project because it only depends on PaddleOCR. Video-subtitle-extractor also utilizes Video-Subfinder under the hood and this seems to result in sometimes poor results. So I find this repo really promising.
Maybe you are interested in checking out my GUI version. I'm interested in your feedback.